### PR TITLE
Add transactional email verification and password recovery flows

### DIFF
--- a/eccomfy-site/README.md
+++ b/eccomfy-site/README.md
@@ -1,23 +1,39 @@
 # Eccomfy — Packaging personalizado (Next.js + Tailwind)
 
-Inspirado en el flujo de Packlane: catálogo → configuración → precio al instante → checkout.
-Este repo trae **home**, **listado de productos** y una **pantalla inicial de diseño** (placeholder con cálculo simulado).
+Landing, editor 3D simulado y backoffice inspirado en el flujo de Packlane.
 
-## Arranque
+## Requisitos
+
+Antes de arrancar necesitás definir las siguientes variables en un archivo `.env.local`:
+
 ```bash
-npm install
-npm run dev
-# abre http://localhost:3000
+RESEND_API_KEY= # API key de https://resend.com/ para enviar correos transaccionales
+MAIL_FROM="Eccomfy <no-reply@tudominio.com>" # Remitente que verán tus clientes
+APP_URL="http://localhost:3000" # URL pública usada en los enlaces de verificación y reseteo
 ```
 
-## Estructura
-- `app/page.tsx` — Home (hero, estilos, banda de valor)
-- `app/products/page.tsx` — Listado de estilos
-- `app/design/[style]/page.tsx` — Placeholder del diseñador (parámetros + precio simulado)
-- `components/*` — Header, Footer, Cards
-- `public/*` — logos y SVGs de cajas
+> ⚠️ Sin `RESEND_API_KEY` y `MAIL_FROM` no se podrán enviar los códigos de verificación ni los enlaces de restablecimiento.
 
-## Próximos pasos
-- Integrar **editor 3D** (react-three-fiber) + **edición 2D** por cara.
-- Backend de precios (Django/DRF o una API Next) y **autenticación**.
-- Exportar **dieline PDF**.
+## Scripts
+
+```bash
+npm install
+npm run dev       # Levanta el entorno de desarrollo
+npm run build     # Compila la app en modo producción
+```
+
+## Funcionalidades
+
+- Autenticación con verificación obligatoria de email (códigos de 6 dígitos enviados con Resend).
+- Recupero de contraseña mediante enlace temporal (1 hora de vigencia).
+- Panel para staff con gestión de contenidos, usuarios y opciones del editor 3D.
+- Editor de cajas que toma materiales, tamaños, terminaciones y tiradas desde SQLite.
+- Diferenciación total entre usuarios staff y clientes (navegación, accesos y permisos).
+
+## Flujo de verificación y contraseñas
+
+1. **Registro:** el usuario recibe un código en su correo. No puede iniciar sesión hasta validarlo en `/verify-email`.
+2. **Reenvío:** desde la misma página puede solicitar un nuevo código si el anterior venció.
+3. **Olvido de contraseña:** `/forgot-password` envía un enlace válido por 60 minutos. Al usarlo se cierran las sesiones anteriores.
+
+Todo el contenido dinámico (productos destacados, testimonios, métricas, opciones del editor) vive en `data/eccomfy.db` y se administra desde `/admin/*` con un usuario marcado como staff.

--- a/eccomfy-site/app/admin/users/UserRow.tsx
+++ b/eccomfy-site/app/admin/users/UserRow.tsx
@@ -48,6 +48,9 @@ export default function UserRow({ user, isLastStaff }: { user: UserSummary; isLa
               Rol actual: {user.is_staff ? "Staff" : "Cliente"}
               {user.is_staff && isLastStaff ? " (último staff)" : ""}
             </p>
+            <p className="text-xs text-white/50">
+              Estado de email: {user.email_verified ? "Verificado" : "Pendiente"}
+            </p>
           </div>
           <ActionButtons isStaff={user.is_staff} disableDemote={isLastStaff} />
         </div>

--- a/eccomfy-site/app/forgot-password/ForgotPasswordForm.tsx
+++ b/eccomfy-site/app/forgot-password/ForgotPasswordForm.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useFormState, useFormStatus } from "react-dom";
+
+import { forgotPasswordAction, type ForgotPasswordState } from "./actions";
+
+const INITIAL_STATE: ForgotPasswordState = {};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="mt-6 inline-flex w-full items-center justify-center rounded-full bg-brand-yellow px-6 py-3 text-base font-semibold text-brand-navy shadow-lg shadow-brand-navy/10 transition hover:-translate-y-0.5 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+      disabled={pending}
+    >
+      {pending ? "Enviando..." : "Enviar enlace"}
+    </button>
+  );
+}
+
+export default function ForgotPasswordForm() {
+  const [state, formAction] = useFormState(forgotPasswordAction, INITIAL_STATE);
+
+  return (
+    <form action={formAction} className="mt-10 rounded-[2.5rem] border border-white/15 bg-white/5 p-8 backdrop-blur">
+      <div>
+        <label className="text-sm font-medium text-white/80" htmlFor="email">
+          Email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
+          placeholder="nombre@empresa.com"
+        />
+      </div>
+
+      {state.error ? (
+        <p className="mt-6 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-100">{state.error}</p>
+      ) : null}
+
+      {state.success ? (
+        <p className="mt-6 rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          {state.success}
+        </p>
+      ) : null}
+
+      <SubmitButton />
+
+      <p className="mt-6 text-sm text-white/70">
+        ¿Recordaste tu contraseña? {""}
+        <Link href="/login" className="font-semibold text-brand-yellow hover:underline">
+          Volvé al login
+        </Link>
+        .
+      </p>
+    </form>
+  );
+}

--- a/eccomfy-site/app/forgot-password/actions.ts
+++ b/eccomfy-site/app/forgot-password/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { requestPasswordReset } from "@/lib/auth";
+import { MailerNotConfiguredError } from "@/lib/mailer";
+
+export type ForgotPasswordState = {
+  error?: string;
+  success?: string;
+};
+
+export async function forgotPasswordAction(
+  _prev: ForgotPasswordState,
+  formData: FormData,
+): Promise<ForgotPasswordState> {
+  const email = String(formData.get("email") ?? "").trim();
+
+  if (!email) {
+    return { error: "Ingresá el email con el que te registraste." };
+  }
+
+  try {
+    await requestPasswordReset(email);
+  } catch (error) {
+    if (error instanceof MailerNotConfiguredError) {
+      return { error: error.message };
+    }
+    console.error("forgotPasswordAction", error);
+    return { error: "No pudimos enviar el correo de restablecimiento. Intentá más tarde." };
+  }
+
+  return {
+    success:
+      "Si el email está registrado, vas a recibir un enlace para crear una nueva contraseña en los próximos minutos.",
+  };
+}

--- a/eccomfy-site/app/forgot-password/page.tsx
+++ b/eccomfy-site/app/forgot-password/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+import ForgotPasswordForm from "./ForgotPasswordForm";
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="container-xl py-20">
+      <div className="rounded-[3rem] border border-white/15 bg-white/5 p-12 shadow-card backdrop-blur">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Recuperar acceso</p>
+        <h1 className="mt-4 max-w-3xl text-4xl font-semibold text-white sm:text-5xl">
+          Te enviamos un enlace para restablecer tu contraseña
+        </h1>
+        <p className="mt-4 max-w-2xl text-white/75">
+          Ingresá tu email y te mandaremos un enlace temporal para que elijas una nueva contraseña. Por seguridad, el enlace expira a los 60 minutos.
+        </p>
+
+        <ForgotPasswordForm />
+
+        <div className="mt-10 flex flex-wrap items-center gap-4 rounded-3xl border border-white/10 bg-white/10 p-6 text-sm text-white/70">
+          <span>
+            ¿No tenés cuenta todavía? {""}
+            <Link href="/register" className="font-semibold text-brand-yellow hover:underline">
+              Creá una gratis
+            </Link>
+            .
+          </span>
+          <Link href="/login" className="ml-auto inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 font-semibold text-white transition hover:bg-white/10">
+            Volver al login
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/eccomfy-site/app/login/LoginForm.tsx
+++ b/eccomfy-site/app/login/LoginForm.tsx
@@ -22,6 +22,9 @@ function SubmitButton() {
 
 export default function LoginForm() {
   const [state, formAction] = useFormState(loginAction, INITIAL_STATE);
+  const verificationUrl = state.needsVerification
+    ? `/verify-email?email=${encodeURIComponent(state.email ?? "")}`
+    : "/verify-email";
 
   return (
     <form action={formAction} className="mt-8 space-y-4">
@@ -34,6 +37,7 @@ export default function LoginForm() {
           name="email"
           type="email"
           required
+          defaultValue={state.email}
           className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
           placeholder="nombre@empresa.com"
         />
@@ -54,12 +58,28 @@ export default function LoginForm() {
       </div>
 
       {state.error ? (
-        <p className="rounded-2xl border border-brand-yellow/40 bg-brand-yellow/10 px-4 py-3 text-sm text-brand-yellow">
-          {state.error}
-        </p>
+        <div className="space-y-3 rounded-2xl border border-brand-yellow/40 bg-brand-yellow/10 px-4 py-3 text-sm text-brand-yellow">
+          <p>{state.error}</p>
+          {state.needsVerification ? (
+            <p>
+              Completá la verificación desde {""}
+              <Link href={verificationUrl} className="font-semibold underline">
+                esta página
+              </Link>{" "}
+              para poder ingresar.
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       <SubmitButton />
+
+      <p className="text-sm text-white/70">
+        ¿Olvidaste tu contraseña? {""}
+        <Link href="/forgot-password" className="font-semibold text-brand-yellow hover:underline">
+          Restablecela acá
+        </Link>
+      </p>
 
       <p className="text-sm text-white/70">
         ¿No tenés cuenta? {""}

--- a/eccomfy-site/app/login/actions.ts
+++ b/eccomfy-site/app/login/actions.ts
@@ -2,10 +2,12 @@
 
 import { redirect } from "next/navigation";
 
-import { signIn, verifyUser } from "@/lib/auth";
+import { EmailNotVerifiedError, signIn, verifyUser } from "@/lib/auth";
 
 export type LoginState = {
   error?: string;
+  needsVerification?: boolean;
+  email?: string;
 };
 
 export async function loginAction(_prev: LoginState, formData: FormData): Promise<LoginState> {
@@ -16,11 +18,24 @@ export async function loginAction(_prev: LoginState, formData: FormData): Promis
     return { error: "Ingresá tu email y contraseña." };
   }
 
-  const user = await verifyUser(email, password);
-  if (!user) {
-    return { error: "Credenciales incorrectas." };
+  try {
+    const user = await verifyUser(email, password);
+    if (!user) {
+      return { error: "Credenciales incorrectas.", email };
+    }
+
+    await signIn(user);
+  } catch (error) {
+    if (error instanceof EmailNotVerifiedError) {
+      return {
+        error: "Necesitás verificar tu email antes de ingresar.",
+        needsVerification: true,
+        email,
+      };
+    }
+    console.error("loginAction", error);
+    return { error: "No pudimos iniciar sesión. Intentá de nuevo.", email };
   }
 
-  await signIn(user);
   redirect("/account");
 }

--- a/eccomfy-site/app/reset-password/[token]/ResetPasswordForm.tsx
+++ b/eccomfy-site/app/reset-password/[token]/ResetPasswordForm.tsx
@@ -3,9 +3,9 @@
 import Link from "next/link";
 import { useFormState, useFormStatus } from "react-dom";
 
-import { registerAction, type RegisterState } from "./actions";
+import { resetPasswordAction, type ResetPasswordState } from "./actions";
 
-const INITIAL_STATE: RegisterState = {};
+const INITIAL_STATE: ResetPasswordState = {};
 
 function SubmitButton() {
   const { pending } = useFormStatus();
@@ -15,47 +15,21 @@ function SubmitButton() {
       className="mt-6 inline-flex w-full items-center justify-center rounded-full bg-brand-yellow px-6 py-3 text-base font-semibold text-brand-navy shadow-lg shadow-brand-navy/10 transition hover:-translate-y-0.5 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
       disabled={pending}
     >
-      {pending ? "Creando cuenta..." : "Crear cuenta"}
+      {pending ? "Guardando..." : "Actualizar contraseña"}
     </button>
   );
 }
 
-export default function RegisterForm() {
-  const [state, formAction] = useFormState(registerAction, INITIAL_STATE);
+export default function ResetPasswordForm({ token }: { token: string }) {
+  const [state, formAction] = useFormState(resetPasswordAction, INITIAL_STATE);
 
   return (
-    <form action={formAction} className="mt-8 space-y-4">
-      <div>
-        <label className="text-sm font-medium text-white/80" htmlFor="name">
-          Nombre y apellido
-        </label>
-        <input
-          id="name"
-          name="name"
-          required
-          className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-          placeholder="Tu nombre completo"
-        />
-      </div>
-
-      <div>
-        <label className="text-sm font-medium text-white/80" htmlFor="email">
-          Email corporativo
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          required
-          className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-          placeholder="nombre@empresa.com"
-        />
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
+    <form action={formAction} className="mt-10 rounded-[2.5rem] border border-white/15 bg-white/5 p-8 backdrop-blur">
+      <input type="hidden" name="token" value={token} />
+      <div className="grid gap-6 md:grid-cols-2">
         <div>
           <label className="text-sm font-medium text-white/80" htmlFor="password">
-            Contraseña
+            Nueva contraseña
           </label>
           <input
             id="password"
@@ -84,22 +58,17 @@ export default function RegisterForm() {
       </div>
 
       {state.error ? (
-        <p className="rounded-2xl border border-brand-yellow/40 bg-brand-yellow/10 px-4 py-3 text-sm text-brand-yellow">
-          {state.error}
-        </p>
+        <p className="mt-6 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-100">{state.error}</p>
       ) : null}
 
       <SubmitButton />
 
-      <p className="text-sm text-white/70">
-        Te vamos a enviar un código de verificación al email ingresado. Necesitás validarlo antes de acceder al panel.
-      </p>
-
-      <p className="text-sm text-white/70">
-        ¿Ya tenés cuenta? {""}
+      <p className="mt-6 text-sm text-white/70">
+        ¿Recordaste tu contraseña? {""}
         <Link href="/login" className="font-semibold text-brand-yellow hover:underline">
-          Iniciá sesión
+          Volvé al login
         </Link>
+        .
       </p>
     </form>
   );

--- a/eccomfy-site/app/reset-password/[token]/actions.ts
+++ b/eccomfy-site/app/reset-password/[token]/actions.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { PasswordResetError, resetPasswordWithToken, signIn } from "@/lib/auth";
+
+export type ResetPasswordState = {
+  error?: string;
+};
+
+export async function resetPasswordAction(
+  _prev: ResetPasswordState,
+  formData: FormData,
+): Promise<ResetPasswordState> {
+  const token = String(formData.get("token") ?? "");
+  const password = String(formData.get("password") ?? "");
+  const confirm = String(formData.get("confirm") ?? "");
+
+  if (!token) {
+    return { error: "El enlace no es válido. Solicitá uno nuevo." };
+  }
+
+  if (!password || !confirm) {
+    return { error: "Completá los dos campos de contraseña." };
+  }
+
+  if (password.length < 8) {
+    return { error: "La contraseña debe tener al menos 8 caracteres." };
+  }
+
+  if (password !== confirm) {
+    return { error: "Las contraseñas no coinciden." };
+  }
+
+  try {
+    const user = await resetPasswordWithToken(token, password);
+    await signIn(user);
+  } catch (error) {
+    if (error instanceof PasswordResetError) {
+      if (error.code === "TOKEN_EXPIRED") {
+        return { error: "El enlace expiró. Solicitá uno nuevo desde la página de recuperar contraseña." };
+      }
+      return { error: "El enlace no es válido. Pedí otro e intentá nuevamente." };
+    }
+    console.error("resetPasswordAction", error);
+    return { error: "No pudimos actualizar tu contraseña. Intentá nuevamente." };
+  }
+
+  redirect("/account");
+}

--- a/eccomfy-site/app/reset-password/[token]/page.tsx
+++ b/eccomfy-site/app/reset-password/[token]/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+import ResetPasswordForm from "./ResetPasswordForm";
+
+export default function ResetPasswordPage({ params }: { params: { token: string } }) {
+  const { token } = params;
+
+  return (
+    <div className="container-xl py-20">
+      <div className="rounded-[3rem] border border-white/15 bg-white/5 p-12 shadow-card backdrop-blur">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Crear nueva contraseña</p>
+        <h1 className="mt-4 max-w-3xl text-4xl font-semibold text-white sm:text-5xl">
+          Elegí una contraseña segura para seguir usando Eccomfy
+        </h1>
+        <p className="mt-4 max-w-2xl text-white/75">
+          El enlace que abriste expira a los 60 minutos. Una vez guardados los cambios vamos a cerrar todas las sesiones activas por seguridad.
+        </p>
+
+        <ResetPasswordForm token={token} />
+
+        <div className="mt-10 flex flex-wrap items-center gap-4 rounded-3xl border border-white/10 bg-white/10 p-6 text-sm text-white/70">
+          <span>
+            ¿No pediste este cambio? {""}
+            <a href="mailto:contacto@eccomfy.com" className="font-semibold text-brand-yellow hover:underline">
+              Escribinos al soporte
+            </a>
+            .
+          </span>
+          <Link href="/forgot-password" className="ml-auto inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 font-semibold text-white transition hover:bg-white/10">
+            Solicitar otro enlace
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/eccomfy-site/app/verify-email/VerifyEmailForm.tsx
+++ b/eccomfy-site/app/verify-email/VerifyEmailForm.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import Link from "next/link";
+import { useFormState, useFormStatus } from "react-dom";
+
+import {
+  ResendVerificationState,
+  VerifyEmailState,
+  resendVerificationAction,
+  verifyEmailAction,
+} from "./actions";
+
+const VERIFY_INITIAL_STATE: VerifyEmailState = {};
+const RESEND_INITIAL_STATE: ResendVerificationState = {};
+
+function VerifyButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="mt-6 inline-flex w-full items-center justify-center rounded-full bg-brand-yellow px-6 py-3 text-base font-semibold text-brand-navy shadow-lg shadow-brand-navy/10 transition hover:-translate-y-0.5 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+      disabled={pending}
+    >
+      {pending ? "Verificando..." : "Confirmar email"}
+    </button>
+  );
+}
+
+function ResendButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="inline-flex w-full items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? "Enviando..." : "Reenviar código"}
+    </button>
+  );
+}
+
+export default function VerifyEmailForm({ defaultEmail = "" }: { defaultEmail?: string }) {
+  const [verifyState, verifyAction] = useFormState(verifyEmailAction, VERIFY_INITIAL_STATE);
+  const [resendState, resendAction] = useFormState(resendVerificationAction, RESEND_INITIAL_STATE);
+  const emailValue = verifyState.email ?? defaultEmail;
+  const resendEmailValue = emailValue || defaultEmail;
+
+  return (
+    <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,0.35fr)]">
+      <form action={verifyAction} className="rounded-[2.5rem] border border-white/15 bg-white/5 p-8 backdrop-blur">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/60">Paso obligatorio</p>
+        <h2 className="mt-3 text-3xl font-semibold text-white">Verificá tu email</h2>
+        <p className="mt-3 text-sm text-white/70">
+          Te enviamos un código de seis dígitos al correo con el que te registraste. Ingresalo a continuación para activar tu cuenta.
+        </p>
+
+        <div className="mt-8 space-y-6">
+          <div>
+            <label className="text-sm font-medium text-white/80" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              defaultValue={emailValue}
+              className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
+              placeholder="nombre@empresa.com"
+            />
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-white/80" htmlFor="code">
+              Código de verificación
+            </label>
+            <input
+              id="code"
+              name="code"
+              inputMode="numeric"
+              pattern="[0-9]{6}"
+              minLength={6}
+              maxLength={6}
+              required
+              className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
+              placeholder="000000"
+            />
+            <p className="mt-2 text-xs text-white/60">El código vence a los 30 minutos.</p>
+          </div>
+        </div>
+
+        {verifyState.error ? (
+          <p className="mt-6 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+            {verifyState.error}
+          </p>
+        ) : null}
+
+        <VerifyButton />
+
+        <p className="mt-4 text-xs text-white/60">
+          Si ya verificaste tu email, podés {""}
+          <Link href="/login" className="font-semibold text-brand-yellow hover:underline">
+            iniciar sesión
+          </Link>
+          .
+        </p>
+      </form>
+
+      <form action={resendAction} className="rounded-[2.5rem] border border-white/15 bg-white/5 p-8 backdrop-blur">
+        <h3 className="text-xl font-semibold text-white">¿No recibiste el código?</h3>
+        <p className="mt-3 text-sm text-white/70">
+          Enviá nuevamente el correo de verificación. Revisá la carpeta de spam o promociones si no aparece en tu bandeja principal.
+        </p>
+
+        <div className="mt-6">
+          <label className="text-sm font-medium text-white/80" htmlFor="resend-email">
+            Email
+          </label>
+          <input
+            id="resend-email"
+            name="email"
+            type="email"
+            required
+            defaultValue={resendEmailValue}
+            className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
+            placeholder="nombre@empresa.com"
+          />
+        </div>
+
+        {resendState.error ? (
+          <p className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-xs text-red-100">
+            {resendState.error}
+          </p>
+        ) : null}
+
+        {resendState.success ? (
+          <p className="mt-4 rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-xs text-emerald-100">
+            {resendState.success}
+          </p>
+        ) : null}
+
+        <div className="mt-6">
+          <ResendButton />
+        </div>
+
+        <p className="mt-4 text-xs text-white/60">
+          ¿Te equivocaste de email al registrarte? {""}
+          <Link href="/register" className="font-semibold text-brand-yellow hover:underline">
+            Creá una cuenta nueva
+          </Link>
+          .
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/eccomfy-site/app/verify-email/actions.ts
+++ b/eccomfy-site/app/verify-email/actions.ts
@@ -1,0 +1,84 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import {
+  EmailVerificationError,
+  resendEmailVerification,
+  signIn,
+  verifyEmailWithCode,
+} from "@/lib/auth";
+import { MailerNotConfiguredError } from "@/lib/mailer";
+
+export type VerifyEmailState = {
+  error?: string;
+  email?: string;
+};
+
+export type ResendVerificationState = {
+  error?: string;
+  success?: string;
+};
+
+export async function verifyEmailAction(
+  _prev: VerifyEmailState,
+  formData: FormData,
+): Promise<VerifyEmailState> {
+  const email = String(formData.get("email") ?? "").trim();
+  const code = String(formData.get("code") ?? "").trim();
+
+  if (!email || !code) {
+    return { error: "Completá tu email y el código recibido.", email };
+  }
+
+  try {
+    const user = await verifyEmailWithCode(email, code);
+    await signIn(user);
+  } catch (error) {
+    if (error instanceof EmailVerificationError) {
+      if (error.code === "EMAIL_NOT_FOUND") {
+        return { error: "No encontramos una cuenta con ese email.", email };
+      }
+      if (error.code === "EMAIL_ALREADY_VERIFIED") {
+        return { error: "Este email ya fue verificado. Iniciá sesión.", email };
+      }
+      return { error: "El código ingresado no es válido o expiró.", email };
+    }
+    console.error("verifyEmailAction", error);
+    return { error: "No pudimos verificar tu email. Intentá nuevamente.", email };
+  }
+
+  redirect("/account");
+}
+
+export async function resendVerificationAction(
+  _prev: ResendVerificationState,
+  formData: FormData,
+): Promise<ResendVerificationState> {
+  const email = String(formData.get("email") ?? "").trim();
+
+  if (!email) {
+    return { error: "Ingresá el email con el que te registraste." };
+  }
+
+  try {
+    await resendEmailVerification(email);
+  } catch (error) {
+    if (error instanceof EmailVerificationError) {
+      if (error.code === "EMAIL_NOT_FOUND") {
+        return { error: "No encontramos una cuenta con ese email." };
+      }
+      if (error.code === "EMAIL_ALREADY_VERIFIED") {
+        return { error: "Ese email ya está verificado. Iniciá sesión." };
+      }
+      return { error: "No pudimos generar un nuevo código. Intentá más tarde." };
+    }
+    if (error instanceof MailerNotConfiguredError) {
+      return { error: error.message };
+    }
+    console.error("resendVerificationAction", error);
+    return { error: "No pudimos enviar el código. Intentá más tarde." };
+  }
+
+  return { success: "Enviamos un nuevo código a tu casilla. Revisá también la carpeta de spam." };
+}

--- a/eccomfy-site/app/verify-email/page.tsx
+++ b/eccomfy-site/app/verify-email/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+
+import VerifyEmailForm from "./VerifyEmailForm";
+
+export default function VerifyEmailPage({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}) {
+  const rawEmail = searchParams?.email;
+  const email = typeof rawEmail === "string" ? rawEmail : "";
+
+  return (
+    <div className="container-xl py-20">
+      <div className="rounded-[3rem] border border-white/15 bg-white/5 p-12 shadow-card backdrop-blur-lg">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Activación de cuenta</p>
+        <h1 className="mt-4 max-w-3xl text-4xl font-semibold text-white sm:text-5xl">
+          Confirmá tu email para empezar a diseñar tus cajas personalizadas
+        </h1>
+        <p className="mt-4 max-w-2xl text-white/75">
+          Para proteger tu cuenta necesitamos validar que el correo ingresado existe. El proceso demora segundos y habilita el acceso a las herramientas de Eccomfy.
+        </p>
+
+        <div className="mt-6 flex flex-wrap items-center gap-4 text-sm text-white/60">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-brand-yellow" aria-hidden />
+            Paso 1: verificá tu email
+          </div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-white/40" aria-hidden />
+            Paso 2: accedé al panel y comenzá a diseñar
+          </div>
+        </div>
+
+        <VerifyEmailForm defaultEmail={email} />
+
+        <div className="mt-12 flex flex-wrap items-center gap-4 rounded-3xl border border-white/10 bg-white/10 p-6 text-sm text-white/70">
+          <span className="font-semibold text-white">¿Necesitás ayuda?</span>
+          <span>
+            Escribinos a {""}
+            <a href="mailto:contacto@eccomfy.com" className="font-semibold text-brand-yellow hover:underline">
+              contacto@eccomfy.com
+            </a>{" "}
+            o hablá con el equipo por {""}
+            <a href="https://wa.me/5490000000000" target="_blank" className="font-semibold text-brand-yellow hover:underline">
+              WhatsApp
+            </a>
+            .
+          </span>
+          <Link href="/login" className="ml-auto inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 font-semibold text-white transition hover:bg-white/10">
+            Volver al login
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/eccomfy-site/lib/auth.ts
+++ b/eccomfy-site/lib/auth.ts
@@ -1,13 +1,51 @@
-import { randomBytes } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import bcrypt from "bcryptjs";
 import { unstable_noStore as noStore } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import db, { DbUser } from "./db";
+import { getAppUrl } from "./env";
+import { sendMail } from "./mailer";
 
 const SESSION_COOKIE = "eccomfy_session";
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 días
+const EMAIL_VERIFICATION_TTL_MS = 1000 * 60 * 30; // 30 minutos
+const PASSWORD_RESET_TTL_MS = 1000 * 60 * 60; // 60 minutos
+
+export class EmailNotVerifiedError extends Error {
+  constructor() {
+    super("EMAIL_NOT_VERIFIED");
+    this.name = "EmailNotVerifiedError";
+  }
+}
+
+export type EmailVerificationErrorCode =
+  | "EMAIL_NOT_FOUND"
+  | "EMAIL_ALREADY_VERIFIED"
+  | "VERIFICATION_CODE_INVALID";
+
+export class EmailVerificationError extends Error {
+  readonly code: EmailVerificationErrorCode;
+
+  constructor(code: EmailVerificationErrorCode) {
+    super(code);
+    this.code = code;
+    this.name = "EmailVerificationError";
+  }
+}
+
+export type PasswordResetErrorCode = "TOKEN_INVALID" | "TOKEN_EXPIRED";
+
+export class PasswordResetError extends Error {
+  readonly code: PasswordResetErrorCode;
+
+  constructor(code: PasswordResetErrorCode) {
+    super(code);
+    this.code = code;
+    this.name = "PasswordResetError";
+  }
+}
 
 export type SafeUser = {
   id: number;
@@ -15,6 +53,7 @@ export type SafeUser = {
   email: string;
   created_at: string;
   is_staff: boolean;
+  email_verified: boolean;
 };
 
 type SessionRow = {
@@ -26,6 +65,23 @@ type SessionRow = {
   user_email: string;
   user_created_at: string;
   user_is_staff: number;
+  user_email_verified_at: string | null;
+};
+
+type EmailVerificationTokenRow = {
+  id: number;
+  user_id: number;
+  code_hash: string;
+  expires_at: string;
+  consumed_at: string | null;
+};
+
+type PasswordResetTokenRow = {
+  id: number;
+  user_id: number;
+  token_hash: string;
+  expires_at: string;
+  consumed_at: string | null;
 };
 
 const normalizeEmail = (email: string) => email.trim().toLowerCase();
@@ -45,6 +101,7 @@ const mapUser = (row: DbUser): SafeUser => ({
   email: row.email,
   created_at: normalizeTimestamp(row.created_at),
   is_staff: Boolean(row.is_staff),
+  email_verified: Boolean(row.email_verified_at),
 });
 
 const hasAnyStaff = (): boolean => {
@@ -54,10 +111,229 @@ const hasAnyStaff = (): boolean => {
   return (result?.count ?? 0) > 0;
 };
 
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const generateVerificationCode = (): string => {
+  return String(100000 + Math.floor(Math.random() * 900000));
+};
+
+async function createEmailVerificationToken(userId: number): Promise<{ code: string; expiresAt: Date }> {
+  db.prepare("DELETE FROM email_verification_tokens WHERE user_id = ?").run(userId);
+
+  const code = generateVerificationCode();
+  const codeHash = await bcrypt.hash(code, 10);
+  const expiresAtIso = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MS).toISOString();
+
+  db.prepare(
+    "INSERT INTO email_verification_tokens (user_id, code_hash, expires_at) VALUES (?, ?, ?)",
+  ).run(userId, codeHash, expiresAtIso);
+
+  return { code, expiresAt: new Date(expiresAtIso) };
+}
+
+function getLatestEmailVerificationToken(userId: number): EmailVerificationTokenRow | undefined {
+  const row = db
+    .prepare<EmailVerificationTokenRow>(
+      "SELECT id, user_id, code_hash, expires_at, consumed_at FROM email_verification_tokens WHERE user_id = ? ORDER BY created_at DESC LIMIT 1",
+    )
+    .get(userId);
+  return row;
+}
+
+function markVerificationTokenConsumed(tokenId: number): void {
+  db.prepare("UPDATE email_verification_tokens SET consumed_at = CURRENT_TIMESTAMP WHERE id = ?").run(tokenId);
+}
+
+function getUserByIdInternal(id: number): DbUser | undefined {
+  return db
+    .prepare(
+      "SELECT id, name, email, password_hash, created_at, is_staff, email_verified_at FROM users WHERE id = ?",
+    )
+    .get(id) as DbUser | undefined;
+}
+
+function markUserEmailVerified(userId: number): DbUser {
+  db.prepare("UPDATE users SET email_verified_at = CURRENT_TIMESTAMP WHERE id = ?").run(userId);
+  const updated = getUserByIdInternal(userId);
+  if (!updated) {
+    throw new Error("USER_NOT_FOUND");
+  }
+  return updated;
+}
+
+export async function sendEmailVerificationEmail(user: {
+  id: number;
+  email: string;
+  name: string;
+}): Promise<Date> {
+  const { code, expiresAt } = await createEmailVerificationToken(user.id);
+  const appUrl = getAppUrl();
+  const verifyUrl = `${appUrl}/verify-email?email=${encodeURIComponent(user.email)}`;
+  const minutes = Math.round(EMAIL_VERIFICATION_TTL_MS / (1000 * 60));
+  const displayName = user.name?.trim() || user.email;
+  const subject = "Verificá tu cuenta en Eccomfy";
+
+  const html = `
+    <p>Hola ${escapeHtml(displayName)},</p>
+    <p>Usá este código para verificar tu cuenta de Eccomfy:</p>
+    <p style="font-size:32px;font-weight:700;letter-spacing:6px;margin:24px 0;">${code}</p>
+    <p>El código vence en ${minutes} minutos.</p>
+    <p>Si preferís, también podés verificar tu email haciendo clic en este enlace:</p>
+    <p><a href="${verifyUrl}">${verifyUrl}</a></p>
+    <p>Si no creaste una cuenta, podés ignorar este mensaje.</p>
+  `;
+
+  const text = `Hola ${displayName},\n\nTu código de verificación es: ${code}.\nVence en ${minutes} minutos.\nIngresá el código en ${verifyUrl} para activar tu cuenta.\n\nSi no creaste una cuenta, ignorá este email.`;
+
+  await sendMail({ to: user.email, subject, html, text });
+
+  return expiresAt;
+}
+
+export async function verifyEmailWithCode(email: string, code: string): Promise<SafeUser> {
+  const user = findUserByEmail(email);
+  if (!user) {
+    throw new EmailVerificationError("EMAIL_NOT_FOUND");
+  }
+
+  if (user.email_verified_at) {
+    throw new EmailVerificationError("EMAIL_ALREADY_VERIFIED");
+  }
+
+  const token = getLatestEmailVerificationToken(user.id);
+  if (!token) {
+    throw new EmailVerificationError("VERIFICATION_CODE_INVALID");
+  }
+
+  if (token.consumed_at) {
+    throw new EmailVerificationError("VERIFICATION_CODE_INVALID");
+  }
+
+  const expiresAt = new Date(token.expires_at);
+  if (Number.isNaN(expiresAt.getTime()) || expiresAt.getTime() < Date.now()) {
+    db.prepare("DELETE FROM email_verification_tokens WHERE id = ?").run(token.id);
+    throw new EmailVerificationError("VERIFICATION_CODE_INVALID");
+  }
+
+  const isMatch = await bcrypt.compare(code, token.code_hash);
+  if (!isMatch) {
+    throw new EmailVerificationError("VERIFICATION_CODE_INVALID");
+  }
+
+  markVerificationTokenConsumed(token.id);
+  const updatedUser = markUserEmailVerified(user.id);
+
+  if (!updatedUser.is_staff && !hasAnyStaff()) {
+    db.prepare("UPDATE users SET is_staff = 1 WHERE id = ?").run(updatedUser.id);
+    updatedUser.is_staff = 1;
+  }
+
+  return mapUser(updatedUser);
+}
+
+export async function resendEmailVerification(email: string): Promise<Date> {
+  const user = findUserByEmail(email);
+  if (!user) {
+    throw new EmailVerificationError("EMAIL_NOT_FOUND");
+  }
+
+  if (user.email_verified_at) {
+    throw new EmailVerificationError("EMAIL_ALREADY_VERIFIED");
+  }
+
+  return sendEmailVerificationEmail(user);
+}
+
+async function createPasswordResetToken(userId: number): Promise<{ token: string; expiresAt: Date }> {
+  db.prepare("DELETE FROM password_reset_tokens WHERE user_id = ?").run(userId);
+
+  const token = randomBytes(48).toString("hex");
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  const expiresAtIso = new Date(Date.now() + PASSWORD_RESET_TTL_MS).toISOString();
+
+  db.prepare(
+    "INSERT INTO password_reset_tokens (user_id, token_hash, expires_at) VALUES (?, ?, ?)",
+  ).run(userId, tokenHash, expiresAtIso);
+
+  return { token, expiresAt: new Date(expiresAtIso) };
+}
+
+const revokeSessionsForUser = (userId: number): void => {
+  db.prepare("DELETE FROM sessions WHERE user_id = ?").run(userId);
+};
+
+export async function requestPasswordReset(email: string): Promise<void> {
+  const user = findUserByEmail(email);
+  if (!user || !user.email_verified_at) {
+    return;
+  }
+
+  const { token } = await createPasswordResetToken(user.id);
+  const appUrl = getAppUrl();
+  const resetUrl = `${appUrl}/reset-password/${token}`;
+  const minutes = Math.round(PASSWORD_RESET_TTL_MS / (1000 * 60));
+  const displayName = user.name?.trim() || user.email;
+  const subject = "Restablecé tu contraseña en Eccomfy";
+
+  const html = `
+    <p>Hola ${escapeHtml(displayName)},</p>
+    <p>Recibimos una solicitud para restablecer tu contraseña.</p>
+    <p>Hacé clic en el siguiente botón para crear una nueva contraseña. Este enlace vence en ${minutes} minutos.</p>
+    <p><a href="${resetUrl}">${resetUrl}</a></p>
+    <p>Si no solicitaste el cambio, ignorá este mensaje.</p>
+  `;
+
+  const text = `Hola ${displayName},\n\nUsá este enlace para crear una nueva contraseña (vence en ${minutes} minutos): ${resetUrl}\n\nSi no solicitaste el cambio, podés ignorar este correo.`;
+
+  await sendMail({ to: user.email, subject, html, text });
+}
+
+export async function resetPasswordWithToken(token: string, newPassword: string): Promise<SafeUser> {
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  const row = db
+    .prepare<PasswordResetTokenRow>(
+      "SELECT id, user_id, token_hash, expires_at, consumed_at FROM password_reset_tokens WHERE token_hash = ?",
+    )
+    .get(tokenHash);
+
+  if (!row) {
+    throw new PasswordResetError("TOKEN_INVALID");
+  }
+
+  if (row.consumed_at) {
+    throw new PasswordResetError("TOKEN_INVALID");
+  }
+
+  const expiresAt = new Date(row.expires_at);
+  if (Number.isNaN(expiresAt.getTime()) || expiresAt.getTime() < Date.now()) {
+    db.prepare("DELETE FROM password_reset_tokens WHERE id = ?").run(row.id);
+    throw new PasswordResetError("TOKEN_EXPIRED");
+  }
+
+  const passwordHash = await bcrypt.hash(newPassword, 10);
+  db.prepare("UPDATE users SET password_hash = ? WHERE id = ?").run(passwordHash, row.user_id);
+  db.prepare("UPDATE password_reset_tokens SET consumed_at = CURRENT_TIMESTAMP WHERE id = ?").run(row.id);
+  db.prepare("DELETE FROM password_reset_tokens WHERE user_id = ? AND id != ?").run(row.user_id, row.id);
+  revokeSessionsForUser(row.user_id);
+
+  const updated = getUserByIdInternal(row.user_id);
+  if (!updated) {
+    throw new PasswordResetError("TOKEN_INVALID");
+  }
+
+  return mapUser(updated);
+}
+
 export function findUserByEmail(email: string): DbUser | undefined {
   const row = db
     .prepare(
-      "SELECT id, name, email, password_hash, created_at, is_staff FROM users WHERE email = ?",
+      "SELECT id, name, email, password_hash, created_at, is_staff, email_verified_at FROM users WHERE email = ?",
     )
     .get(normalizeEmail(email)) as DbUser | undefined;
   return row;
@@ -76,7 +352,7 @@ export async function createUser(name: string, email: string, password: string):
     const info = insert.run(cleanName, cleanEmail, passwordHash, makeStaff ? 1 : 0);
     const userRow = db
       .prepare(
-        "SELECT id, name, email, password_hash, created_at, is_staff FROM users WHERE id = ?",
+        "SELECT id, name, email, password_hash, created_at, is_staff, email_verified_at FROM users WHERE id = ?",
       )
       .get(Number(info.lastInsertRowid)) as DbUser | undefined;
 
@@ -102,6 +378,10 @@ export async function verifyUser(email: string, password: string): Promise<SafeU
 
   const isValid = await bcrypt.compare(password, user.password_hash);
   if (!isValid) return null;
+
+  if (!user.email_verified_at) {
+    throw new EmailNotVerifiedError();
+  }
 
   let record = user;
   if (!record.is_staff && !hasAnyStaff()) {
@@ -141,6 +421,7 @@ function mapSessionRow(row: SessionRow | undefined): { user: SafeUser; expiresAt
       email: row.user_email,
       created_at: normalizeTimestamp(row.user_created_at),
       is_staff: Boolean(row.user_is_staff),
+      email_verified: Boolean(row.user_email_verified_at),
     },
     expiresAt,
   };
@@ -157,7 +438,8 @@ export function getSessionByToken(token: string): { user: SafeUser; expiresAt: D
         u.name as user_name,
         u.email as user_email,
         u.created_at as user_created_at,
-        u.is_staff as user_is_staff
+        u.is_staff as user_is_staff,
+        u.email_verified_at as user_email_verified_at
       FROM sessions s
       JOIN users u ON u.id = s.user_id
       WHERE s.token = ?

--- a/eccomfy-site/lib/env.ts
+++ b/eccomfy-site/lib/env.ts
@@ -1,0 +1,14 @@
+export function getAppUrl(): string {
+  const envUrl = process.env.APP_URL?.trim();
+  if (envUrl) {
+    return envUrl.replace(/\/$/, "");
+  }
+
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) {
+    const prefix = vercelUrl.startsWith("http") ? "" : "https://";
+    return `${prefix}${vercelUrl.replace(/\/$/, "")}`;
+  }
+
+  return "http://localhost:3000";
+}

--- a/eccomfy-site/lib/mailer.ts
+++ b/eccomfy-site/lib/mailer.ts
@@ -1,0 +1,56 @@
+export class MailerNotConfiguredError extends Error {
+  constructor() {
+    super(
+      "El servicio de correo no está configurado. Definí RESEND_API_KEY y MAIL_FROM en las variables de entorno.",
+    );
+    this.name = "MailerNotConfiguredError";
+  }
+}
+
+export type SendMailInput = {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+};
+
+const RESEND_ENDPOINT = process.env.RESEND_API_URL?.trim() || "https://api.resend.com/emails";
+
+export async function sendMail({ to, subject, html, text }: SendMailInput): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const from = process.env.MAIL_FROM?.trim();
+
+  if (!apiKey || !from) {
+    throw new MailerNotConfiguredError();
+  }
+
+  const payload = {
+    from,
+    to: [to],
+    subject,
+    html,
+    text: text ?? html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim(),
+  };
+
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const data = (await response.json()) as { message?: string } | undefined;
+      if (data?.message) {
+        message = data.message;
+      }
+    } catch (error) {
+      // ignore JSON parse errors
+    }
+    throw new Error(`MAIL_SEND_FAILED:${message}`);
+  }
+}

--- a/eccomfy-site/lib/users.ts
+++ b/eccomfy-site/lib/users.ts
@@ -6,6 +6,7 @@ export type UserSummary = {
   email: string;
   is_staff: boolean;
   created_at: string;
+  email_verified: boolean;
 };
 
 const mapRow = (row: {
@@ -14,12 +15,14 @@ const mapRow = (row: {
   email: string;
   is_staff: number;
   created_at: string;
+  email_verified_at: string | null;
 }): UserSummary => ({
   id: row.id,
   name: row.name,
   email: row.email,
   is_staff: Boolean(row.is_staff),
   created_at: row.created_at,
+  email_verified: Boolean(row.email_verified_at),
 });
 
 export function getAllUsers(): UserSummary[] {
@@ -31,7 +34,7 @@ export function getAllUsers(): UserSummary[] {
       is_staff: number;
       created_at: string;
     }>(
-      "SELECT id, name, email, is_staff, created_at FROM users ORDER BY created_at DESC",
+      "SELECT id, name, email, is_staff, created_at, email_verified_at FROM users ORDER BY created_at DESC",
     )
     .all();
   return rows.map(mapRow);
@@ -45,7 +48,8 @@ export function getUserById(id: number): UserSummary | undefined {
       email: string;
       is_staff: number;
       created_at: string;
-    }>("SELECT id, name, email, is_staff, created_at FROM users WHERE id = ?")
+      email_verified_at: string | null;
+    }>("SELECT id, name, email, is_staff, created_at, email_verified_at FROM users WHERE id = ?")
     .get(id);
   return row ? mapRow(row) : undefined;
 }
@@ -57,4 +61,8 @@ export function setUserStaff(id: number, isStaff: boolean): void {
 export function getStaffCount(): number {
   const row = db.prepare<{ count: number }>("SELECT COUNT(*) as count FROM users WHERE is_staff = 1").get();
   return row?.count ?? 0;
+}
+
+export function deleteUserById(id: number): void {
+  db.prepare("DELETE FROM users WHERE id = ?").run(id);
 }


### PR DESCRIPTION
## Summary
- require email verification with Resend-powered codes before allowing sessions and expose verification/resend screens
- add forgot-password and reset-password flows that issue secure tokens and invalidate existing sessions on update
- extend SQLite schema and admin views to track email status while documenting the new RESEND/MAIL_FROM/.env setup

## Testing
- npm run build *(fails: Next.js cannot fetch Google font in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcf6c89f8833186cc24738bcd04e2