### PR TITLE
Load product catalog from database

### DIFF
--- a/eccomfy-site/app/products/page.tsx
+++ b/eccomfy-site/app/products/page.tsx
@@ -1,14 +1,27 @@
 import StyleCard from "../../components/StyleCard";
+import { getProductStyles } from "@/lib/content";
 
 export default function Products() {
+  const styles = getProductStyles();
+
   return (
     <div className="container-xl py-12">
       <h1 className="text-3xl font-bold mb-8">Productos</h1>
-      <div className="grid md:grid-cols-3 gap-6">
-        <StyleCard title="Mailer" desc="Premium para e‑commerce" href="/design/mailer" img="/box-mailer.svg" />
-        <StyleCard title="Shipping Box" desc="Resistente para envíos" href="/design/shipper" img="/box-shipper.svg" />
-        <StyleCard title="Product Box" desc="Liviana para retail" href="/design/product" img="/box-product.svg" />
-      </div>
+      {styles.length > 0 ? (
+        <div className="grid gap-6 md:grid-cols-3">
+          {styles.map((style) => (
+            <StyleCard
+              key={style.id}
+              title={style.title}
+              desc={style.description}
+              href={style.href}
+              img={style.image}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-brand-navy/70">Aún no hay productos en el catálogo.</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- load the product catalog from the `product_styles` entries in the database
- render each database-backed product with the existing style card component
- show an empty-state message when no products are available yet

## Testing
- `npm run lint` *(fails: command requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e31c3cf1fc8331bdf3ab97d135dbe4