### PR TITLE
Add design catalog landing and update admin links

### DIFF
--- a/eccomfy-site/app/account/page.tsx
+++ b/eccomfy-site/app/account/page.tsx
@@ -80,7 +80,7 @@ export default async function AccountPage() {
                   Configurar opciones de diseño
                 </Link>
                 <Link
-                  href="/design/mailer"
+                  href="/design"
                   className="inline-flex items-center justify-center rounded-full border border-white/30 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
                 >
                   Ir al configurador 3D
@@ -95,7 +95,7 @@ export default async function AccountPage() {
               </p>
               <div className="mt-6 flex flex-wrap gap-3">
                 <Link
-                  href="/design/mailer"
+                  href="/design"
                   className="inline-flex items-center justify-center rounded-full bg-brand-yellow px-5 py-3 text-sm font-semibold text-brand-navy shadow-lg shadow-brand-navy/10 transition hover:-translate-y-0.5 hover:shadow-xl"
                 >
                   Diseñar un mailer
@@ -147,7 +147,7 @@ export default async function AccountPage() {
                   </Link>
                 </li>
                 <li>
-                  <Link href="/design/mailer" className="font-semibold text-brand-yellow hover:underline">
+                  <Link href="/design" className="font-semibold text-brand-yellow hover:underline">
                     Probar el configurador como cliente
                   </Link>
                 </li>
@@ -163,7 +163,7 @@ export default async function AccountPage() {
               <h2 className="text-xl font-semibold">¿Buscás algo puntual?</h2>
               <ul className="mt-4 space-y-3 text-sm text-white/70">
                 <li>
-                  <Link href="/design/mailer" className="font-semibold text-brand-yellow hover:underline">
+                  <Link href="/design" className="font-semibold text-brand-yellow hover:underline">
                     Crear un nuevo diseño desde cero
                   </Link>
                 </li>

--- a/eccomfy-site/app/admin/content/actions.ts
+++ b/eccomfy-site/app/admin/content/actions.ts
@@ -265,9 +265,9 @@ function parsePosition(input: FormDataEntryValue | null): number | null {
 
 function revalidateContentPaths() {
   revalidatePath("/");
+  revalidatePath("/design");
   revalidatePath("/products");
   revalidatePath("/admin/content");
-  revalidatePath("/products");
 }
 
 function parseId(formData: FormData, key = "id"): number | null {

--- a/eccomfy-site/app/admin/design-options/actions.ts
+++ b/eccomfy-site/app/admin/design-options/actions.ts
@@ -5,7 +5,8 @@ import { revalidatePath } from "next/cache";
 import db from "@/lib/db";
 import { requireStaff } from "@/lib/auth";
 
-const DESIGN_PATH = "/design/[style]";
+const DESIGN_INDEX_PATH = "/design";
+const DESIGN_PRODUCT_PATH = "/design/[slug]";
 const ADMIN_PATH = "/admin/design-options";
 
 export type FormState = {
@@ -14,7 +15,8 @@ export type FormState = {
 };
 
 function revalidateDesign() {
-  revalidatePath(DESIGN_PATH);
+  revalidatePath(DESIGN_INDEX_PATH);
+  revalidatePath(DESIGN_PRODUCT_PATH);
   revalidatePath(ADMIN_PATH);
 }
 

--- a/eccomfy-site/app/admin/design-options/page.tsx
+++ b/eccomfy-site/app/admin/design-options/page.tsx
@@ -53,7 +53,7 @@ export default async function DesignOptionsPage() {
             Usuarios
           </Link>
           <Link
-            href="/design/mailer"
+            href="/design"
             className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
           >
             Ver editor

--- a/eccomfy-site/app/design/page.tsx
+++ b/eccomfy-site/app/design/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import StyleCard from "@/components/StyleCard";
+import { getCurrentUser } from "@/lib/auth";
+import { getProductStyles, summarizeProductStyle } from "@/lib/content";
+
+export const metadata: Metadata = {
+  title: "Diseñá packaging personalizado | Eccomfy",
+  description:
+    "Explorá el catálogo de packaging Eccomfy y elegí un modelo para personalizarlo en nuestro editor 3D con cotización instantánea.",
+};
+
+export default async function DesignCatalogPage() {
+  const productStyles = getProductStyles();
+  const user = await getCurrentUser();
+  const isStaff = Boolean(user?.is_staff);
+
+  return (
+    <div className="container-xl space-y-12 py-12 md:space-y-16 md:py-16">
+      <header className="max-w-3xl space-y-4">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+          Catálogo interactivo
+        </p>
+        <h1 className="text-4xl font-semibold text-white sm:text-5xl">
+          Elegí un packaging para empezar a diseñar
+        </h1>
+        <p className="text-base text-white/70 sm:text-lg">
+          Configurá medidas, materiales, acabados y cantidades desde el editor 3D. Cada modelo incluye precios sugeridos y
+          opciones listas para producir.
+        </p>
+      </header>
+
+      {productStyles.length === 0 ? (
+        <div className="rounded-[2.5rem] border border-white/15 bg-white/5 p-10 text-sm text-white/70 backdrop-blur">
+          <p className="text-base font-semibold text-white">
+            Todavía no hay productos disponibles en el catálogo.
+          </p>
+          <p className="mt-3 max-w-2xl">
+            Estamos preparando nuevos modelos para que puedas diseñar packaging en minutos.
+            {isStaff
+              ? " Ingresá al panel de administración para cargar el primero."
+              : " Dejanos tus datos y te avisamos cuando estén online."}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            {isStaff ? (
+              <Link
+                href="/admin/content"
+                className="inline-flex items-center justify-center rounded-full bg-brand-yellow px-5 py-2 text-sm font-semibold text-brand-navy shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
+              >
+                Cargar producto desde el admin
+              </Link>
+            ) : (
+              <Link
+                href="/contact"
+                className="inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+              >
+                Contactanos
+              </Link>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {productStyles.map((style) => {
+            const summary = summarizeProductStyle(style);
+            return (
+              <StyleCard
+                key={style.id}
+                title={style.title}
+                desc={style.description}
+                href={style.href}
+                img={style.image}
+                badges={summary.badges}
+                highlights={summary.highlights}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/eccomfy-site/app/page.tsx
+++ b/eccomfy-site/app/page.tsx
@@ -150,7 +150,7 @@ export default async function Home() {
               </div>
               <div className="flex flex-wrap gap-3">
                 <Link
-                  href="/design/mailer"
+                  href="/design"
                   className="inline-flex items-center justify-center rounded-full bg-brand-yellow px-6 py-3 text-base font-semibold text-brand-navy shadow-lg shadow-brand-navy/20 transition hover:-translate-y-0.5 hover:shadow-xl"
                 >
                   Empezar ahora
@@ -415,7 +415,7 @@ export default async function Home() {
               </p>
             </div>
             <Link
-              href="/design/mailer"
+              href="/design"
               className="inline-flex items-center justify-center rounded-full bg-brand-navy px-6 py-3 text-base font-semibold text-white transition hover:-translate-y-0.5 hover:bg-[#07162E]"
             >
               Diseñar ahora

--- a/eccomfy-site/components/Footer.tsx
+++ b/eccomfy-site/components/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Footer() {
   const navLinks = [
     { href: "/products", label: "Catálogo" },
-    { href: "/design/mailer", label: "Diseñá online" },
+    { href: "/design", label: "Diseñá online" },
     { href: "/contact", label: "Contacto" },
   ];
 

--- a/eccomfy-site/components/Header.tsx
+++ b/eccomfy-site/components/Header.tsx
@@ -28,7 +28,7 @@ export default function Header({ user }: HeaderProps) {
   const navLinks = user?.is_staff
     ? [
         { href: "/products", label: "Productos" },
-        { href: "/design/mailer", label: "Diseñar" },
+        { href: "/design", label: "Diseñar" },
         { href: "/admin/design-options", label: "Opciones" },
         { href: "/admin/users", label: "Usuarios" },
         { href: "/admin/content", label: "Contenido" },
@@ -36,7 +36,7 @@ export default function Header({ user }: HeaderProps) {
       ]
     : [
         { href: "/products", label: "Productos" },
-        { href: "/design/mailer", label: "Diseñar" },
+        { href: "/design", label: "Diseñar" },
         {
           href: user ? "/account" : "/login",
           label: user ? "Mi cuenta" : "Ingresar",
@@ -55,7 +55,7 @@ export default function Header({ user }: HeaderProps) {
           ))}
         </nav>
         <Link
-          href={user ? (user.is_staff ? "/admin/design-options" : "/design/mailer") : "/register"}
+          href={user ? (user.is_staff ? "/admin/design-options" : "/design") : "/register"}
           className="inline-flex items-center justify-center rounded-lg bg-brand-yellow text-brand-navy px-4 py-2 font-semibold hover:opacity-95"
         >
           {user ? (user.is_staff ? "Panel admin" : "Nuevo diseño") : "Crear cuenta"}


### PR DESCRIPTION
## Summary
- add a /design catalog page that lists product styles, highlights, and empty-state guidance for staff
- update navigation, account CTAs, and admin links to send users through the new catalog flow
- ensure admin content actions revalidate the catalog and design option changes refresh both catalog and editor pages

## Testing
- not run (npm run lint prompts to configure ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68e45c36b8188331a8580777c3e000fa