### PR TITLE
Refocus admin product creation workflow

### DIFF
--- a/eccomfy-site/app/admin/products/ProductStyleForm.tsx
+++ b/eccomfy-site/app/admin/products/ProductStyleForm.tsx
@@ -41,7 +41,11 @@ export function ProductStyleForm() {
   const [state, formAction] = useFormState(createProductStyleAction, INITIAL_STATE);
 
   return (
-    <form action={formAction} className="space-y-4 rounded-3xl border border-white/15 bg-white/5 p-6 backdrop-blur">
+    <form
+      action={formAction}
+      encType="multipart/form-data"
+      className="space-y-4 rounded-3xl border border-white/15 bg-white/5 p-6 backdrop-blur"
+    >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h3 className="text-lg font-semibold text-white">Crear producto</h3>
@@ -91,9 +95,10 @@ export function ProductStyleForm() {
             placeholder="/productos/caja-botella.png"
             required
           />
+          <p className="mt-1 text-[11px] text-white/50">Podés cargar una ruta existente o subir una imagen debajo.</p>
         </label>
         <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Posición
+          Posición en el listado
           <input
             name="position"
             type="number"
@@ -105,6 +110,17 @@ export function ProductStyleForm() {
         </label>
       </div>
 
+      <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+        Imagen desde tu computadora
+        <input
+          type="file"
+          name="imageFile"
+          accept="image/*"
+          className="mt-2 block w-full text-sm text-white file:mr-4 file:rounded-full file:border-0 file:bg-brand-yellow file:px-4 file:py-2 file:text-sm file:font-semibold file:text-brand-navy hover:file:bg-brand-yellow/90"
+        />
+        <p className="mt-1 text-[11px] text-white/50">La imagen se guardará en /public/productos/&lt;slug&gt;.</p>
+      </label>
+
       <div className="grid gap-4 md:grid-cols-2">
         <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
           Medidas disponibles
@@ -112,86 +128,89 @@ export function ProductStyleForm() {
             name="sizes"
             rows={4}
             className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Pequeña|120|80|40|1.85\nGrande|200|120|50|2.5"}
+            placeholder={"Caja chica|120|80|40|1.85\nCaja grande|200|120|50|2.5"}
             required
           />
           <p className="mt-1 text-[11px] text-white/50">Formato: Nombre|Ancho|Alto|Profundidad|Precio base (mm y USD).</p>
         </label>
         <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Materiales
-          <textarea
-            name="materials"
-            rows={4}
+          Tipo de producto
+          <input
+            name="productType"
             className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Cartulina premium|Ideal para retail|1\nKraft reciclado|Textura natural|1.1"}
+            placeholder="Caja"
             required
           />
-          <p className="mt-1 text-[11px] text-white/50">Formato: Nombre|Descripción opcional|Multiplicador de precio.</p>
+          <p className="mt-1 text-[11px] text-white/50">Por ejemplo: Caja, Bolsa, Tubo, etc.</p>
         </label>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Acabados
+          Posibilidades (una por línea)
           <textarea
-            name="finishes"
+            name="possibilities"
             rows={4}
             className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Mate soft touch||1\nBarniz UV|Resalta logos|1.2"}
-            required
+            placeholder={"Caja kraft\nCaja reforzada\nBolsa de poliéster"}
           />
+          <p className="mt-1 text-[11px] text-white/50">Se mostrará como variantes sugeridas dentro del producto.</p>
         </label>
         <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Caras impresas
-          <textarea
-            name="printSides"
-            rows={4}
+          Stock disponible
+          <input
+            name="stock"
+            type="number"
+            min={0}
             className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Exterior|Ideal para branding|1\nExterior e interior|Máximo impacto|1.35"}
+            placeholder="250"
             required
           />
-        </label>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Velocidades de producción
-          <textarea
-            name="productionSpeeds"
-            rows={4}
-            className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Estándar|13-18 días hábiles|1\nRápida|7-9 días hábiles|1.3"}
-            required
-          />
-        </label>
-        <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Cantidades disponibles
-          <textarea
-            name="quantities"
-            rows={4}
-            className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Caja de 100|100|1\nCaja de 500|500|0.85"}
-            required
-          />
+          <p className="mt-1 text-[11px] text-white/50">Ingresá las unidades actualmente disponibles.</p>
         </label>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
         <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-          Colores disponibles
+          Colores base de las cajas
           <textarea
-            name="colors"
+            name="baseColors"
             rows={4}
             className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-            placeholder={"Blanco|#FFFFFF|1\nNegro|#111111|1.05"}
+            placeholder={"Blanco\nKraft\nNegro"}
           />
-          <p className="mt-1 text-[11px] text-white/50">Formato: Nombre|Hex opcional|Multiplicador.</p>
+          <p className="mt-1 text-[11px] text-white/50">Cargá un color por línea.</p>
+        </label>
+        <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+          Colores disponibles para serigrafía
+          <textarea
+            name="serigraphyColors"
+            rows={4}
+            className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
+            placeholder={"Azul Eccomfy\nRojo Pantone 485\nVerde institucional"}
+          />
+          <p className="mt-1 text-[11px] text-white/50">Un color por línea, se suman al selector general.</p>
+        </label>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+          Precio unitario de la caja (USD)
+          <input
+            name="unitPrice"
+            type="number"
+            step="0.01"
+            min={0}
+            className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
+            placeholder="5.90"
+            required
+          />
         </label>
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-            Pedido mínimo sugerido
+            Compra mínima
             <input
-              name="minQuantity"
+              name="minPurchase"
               type="number"
               min={0}
               className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
@@ -199,9 +218,9 @@ export function ProductStyleForm() {
             />
           </label>
           <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-            Pedido máximo sugerido
+            Compra máxima
             <input
-              name="maxQuantity"
+              name="maxPurchase"
               type="number"
               min={0}
               className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
@@ -212,14 +231,17 @@ export function ProductStyleForm() {
       </div>
 
       <label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-        Highlights (separá cada punto en una línea)
+        Materiales (uno por línea)
         <textarea
-          name="highlights"
-          rows={3}
+          name="materials"
+          rows={4}
           className="mt-2 w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-brand-yellow focus:outline-none focus:ring-2 focus:ring-brand-yellow/40"
-          placeholder={"Se entrega plegada\nIncluye solapas reforzadas"}
+          placeholder={"Cartón kraft|Textura natural\nCartón reforzado|Doble pared"}
+          required
         />
+        <p className="mt-1 text-[11px] text-white/50">Podés agregar una descripción opcional usando el formato Nombre|Descripción.</p>
       </label>
+
       <FormMessage state={state} />
     </form>
   );

--- a/eccomfy-site/app/design/[slug]/DesignStaffBlock.tsx
+++ b/eccomfy-site/app/design/[slug]/DesignStaffBlock.tsx
@@ -19,7 +19,7 @@ export default function DesignStaffBlock({ product, user }: Props) {
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">Acceso restringido</p>
           <h1 className="mt-3 text-4xl font-semibold text-white">Hola, {user.name.split(" ")[0] || user.name}</h1>
           <p className="mt-4 text-white/70">
-            El editor interactivo está pensado para clientes finales. Como integrante del equipo Eccomfy, gestioná las opciones de {prettyLabel} desde el panel de administración.
+            Esta vista está pensada para clientes finales. Como integrante del equipo Eccomfy, gestioná las fichas técnicas y comerciales de {prettyLabel} desde el panel de administración.
           </p>
           <div className="mt-8 flex flex-wrap gap-3">
             <Link
@@ -42,7 +42,7 @@ export default function DesignStaffBlock({ product, user }: Props) {
             <Image src={product.image} alt={prettyLabel} width={640} height={480} className="h-auto w-full object-contain" />
           </div>
           <p className="mt-6 text-sm text-white/60">
-            Desde la carga de contenidos podés actualizar tamaños, materiales, acabados, colores y tiradas disponibles para este modelo.
+            Desde la sección Productos podés modificar medidas, tipos, colores, stock, precios y materiales disponibles para este modelo.
           </p>
         </div>
       </div>

--- a/eccomfy-site/app/design/[slug]/DesignUpsell.tsx
+++ b/eccomfy-site/app/design/[slug]/DesignUpsell.tsx
@@ -9,38 +9,46 @@ type Props = {
   user: SafeUser | null;
 };
 
-function formatOptionList(values: string[]): string {
-  return values.filter(Boolean).join(" · ") || "Consultá con tu ejecutivo";
-}
-
 export default function DesignUpsell({ product, user }: Props) {
   const { configuration } = product;
   const heroImage = product.image || "/box-mailer.svg";
   const prettyLabel = product.title;
 
-  const sizeSummary = formatOptionList(
-    configuration.sizes.slice(0, 3).map((size) => `${size.label} (${size.width_mm}×${size.height_mm}×${size.depth_mm} mm)`),
+  const sizeSummary = configuration.sizes.map(
+    (size) => `${size.label} (${size.width_mm}×${size.height_mm}×${size.depth_mm} mm)`,
   );
-  const materialSummary = formatOptionList(configuration.materials.slice(0, 3).map((material) => material.label));
-  const finishSummary = formatOptionList(configuration.finishes.slice(0, 3).map((finish) => finish.label));
-  const quantitySummary = formatOptionList(configuration.quantities.slice(0, 4).map((quantity) => `${quantity.quantity} u.`));
-  const speedSummary = configuration.productionSpeeds
-    .map((speed) => (speed.description ? `${speed.label}: ${speed.description}` : speed.label))
-    .join(" · ");
-
-  const optionSets = [
-    { label: "Medidas", value: sizeSummary },
-    { label: "Materiales", value: materialSummary },
-    { label: "Acabados", value: finishSummary },
-    { label: "Tiradas", value: quantitySummary },
-  ];
+  const materialSummary = configuration.materials.map((material) => material.label);
+  const baseColors = configuration.base_colors;
+  const serigraphyColors = configuration.serigraphy_colors;
+  const possibilities = configuration.possibilities;
 
   const userName = user?.name.split(" ")[0] || user?.name;
   const headline = user
-    ? `Hola ${userName}, por favor iniciá sesión con una cuenta válida para continuar.`
-    : "Necesitás iniciar sesión para diseñar tu caja.";
+    ? `Hola ${userName}, recordá que la producción se coordina con el equipo comercial.`
+    : "Necesitás iniciar sesión para solicitar un pedido personalizado.";
 
-  const basePrice = configuration.sizes[0]?.base_price ?? null;
+  const basePrice = configuration.unit_price ?? configuration.sizes[0]?.base_price ?? null;
+  const stockLabel =
+    typeof configuration.stock === "number" ? `${configuration.stock.toLocaleString("es-AR")} unidades disponibles` : "—";
+  const minPurchase =
+    typeof configuration.min_quantity === "number" ? `${configuration.min_quantity.toLocaleString("es-AR")} u.` : "No especificado";
+  const maxPurchase =
+    typeof configuration.max_quantity === "number" ? `${configuration.max_quantity.toLocaleString("es-AR")} u.` : "Consultar";
+
+  const detailItems = [
+    { label: "Tipo de producto", value: configuration.product_type ?? "—" },
+    { label: "Medidas", value: sizeSummary.length ? sizeSummary.join(" · ") : "Definí dimensiones en tu pedido" },
+    { label: "Posibilidades", value: possibilities.length ? possibilities.join(" · ") : "Agregalas desde el panel" },
+    { label: "Materiales", value: materialSummary.length ? materialSummary.join(" · ") : "Pendiente" },
+    { label: "Colores base", value: baseColors.length ? baseColors.join(", ") : "Consultar" },
+    {
+      label: "Serigrafía",
+      value: serigraphyColors.length ? serigraphyColors.join(", ") : "Disponible a medida",
+    },
+    { label: "Stock", value: stockLabel },
+    { label: "Compra mínima", value: minPurchase },
+    { label: "Compra máxima", value: maxPurchase },
+  ];
 
   return (
     <div className="container-xl py-12">
@@ -54,7 +62,7 @@ export default function DesignUpsell({ product, user }: Props) {
               </p>
               <h1 className="text-4xl font-semibold">Previsualización {prettyLabel}</h1>
               <p className="text-brand-navy/70">
-                Ingresá con tu cuenta para desbloquear el editor interactivo. Ahí vas a poder elegir medidas, materiales, colores y tiradas cargadas por el equipo de Eccomfy.
+                Ingresá con tu cuenta para coordinar precios finales, tiempos de producción y confirmar la disponibilidad junto al equipo de Eccomfy.
               </p>
               <div className="mt-6 flex flex-wrap gap-3">
                 {user ? (
@@ -91,38 +99,31 @@ export default function DesignUpsell({ product, user }: Props) {
         </div>
 
         <div className="rounded-[3rem] border border-white/15 bg-white/5 p-8 backdrop-blur">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/60">Próximamente disponible</p>
-          <h2 className="mt-2 text-3xl font-semibold text-white">Ingresá para activar el editor</h2>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/60">Gestión comercial</p>
+          <h2 className="mt-2 text-3xl font-semibold text-white">Ingresá para solicitar una cotización</h2>
           <p className="mt-3 text-white/70">
-            Las medidas, materiales y acabados disponibles se cargan desde tu panel de administración. Iniciá sesión para usarlos y obtener precios en tiempo real.
+            Toda la información comercial y técnica se actualiza desde tu panel de administración. Revisá los detalles antes de enviar una cotización.
           </p>
 
           <div className="mt-6 rounded-3xl border border-white/10 bg-white/10 p-6 text-sm text-white/80">
             <div className="flex items-center gap-2">
-              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-yellow">Configuración Eccomfy</span>
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-yellow">Ficha del producto</span>
               <span className="rounded-full border border-white/20 px-3 py-1 text-xs text-white/60">Actualizable</span>
             </div>
             <ul className="mt-4 space-y-3">
-              {optionSets.map((option) => (
-                <li key={option.label} className="flex justify-between gap-4 border-b border-white/10 pb-3">
-                  <span className="text-white/60">{option.label}</span>
-                  <span className="font-medium text-white text-right">{option.value}</span>
+              {detailItems.map((detail) => (
+                <li key={detail.label} className="flex flex-col gap-1 border-b border-white/10 pb-3 last:border-b-0 last:pb-0">
+                  <span className="text-xs uppercase tracking-[0.25em] text-white/50">{detail.label}</span>
+                  <span className="font-medium text-white">{detail.value}</span>
                 </li>
               ))}
             </ul>
             <div className="mt-6 flex items-baseline gap-2 text-white">
-              <span className="text-sm text-white/60">Precio unitario estimado desde</span>
+              <span className="text-sm text-white/60">Precio unitario de referencia</span>
               <span className="text-3xl font-semibold text-brand-yellow">
                 {basePrice ? `$${basePrice.toFixed(2)}` : "—"}
               </span>
-              <span className="text-xs text-emerald-300">Sujeto a validación</span>
-            </div>
-            <div className="mt-4 space-y-2 text-xs text-white/60">
-              {speedSummary ? (
-                speedSummary.split(" · ").map((item) => <p key={item}>{item}</p>)
-              ) : (
-                <p>Definí la velocidad junto a tu ejecutivo.</p>
-              )}
+              <span className="text-xs text-emerald-300">Confirmar con comercial</span>
             </div>
             <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <Link

--- a/eccomfy-site/app/design/[slug]/page.tsx
+++ b/eccomfy-site/app/design/[slug]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
 import { getProductStyleBySlug } from "@/lib/content";
 
-import DesignerEditor from "./DesignerEditor";
 import DesignUpsell from "./DesignUpsell";
 import DesignStaffBlock from "./DesignStaffBlock";
 
@@ -15,13 +14,9 @@ export default async function DesignPage({ params }: { params: { slug: string } 
 
   const user = await getCurrentUser();
 
-  if (!user) {
-    return <DesignUpsell product={product} user={null} />;
-  }
-
-  if (user.is_staff) {
+  if (user?.is_staff) {
     return <DesignStaffBlock product={product} user={user} />;
   }
 
-  return <DesignerEditor product={product} />;
+  return <DesignUpsell product={product} user={user ?? null} />;
 }

--- a/eccomfy-site/lib/content.ts
+++ b/eccomfy-site/lib/content.ts
@@ -37,6 +37,12 @@ export type ProductConfiguration = {
   highlights: string[];
   min_quantity?: number | null;
   max_quantity?: number | null;
+  product_type?: string | null;
+  possibilities: string[];
+  stock?: number | null;
+  base_colors: string[];
+  serigraphy_colors: string[];
+  unit_price?: number | null;
 };
 
 export type ProductStyle = {
@@ -81,6 +87,12 @@ const DEFAULT_CONFIGURATION: ProductConfiguration = {
   highlights: [],
   min_quantity: null,
   max_quantity: null,
+  product_type: null,
+  possibilities: [],
+  stock: null,
+  base_colors: [],
+  serigraphy_colors: [],
+  unit_price: null,
 };
 
 type RawProductConfig = Partial<Omit<ProductConfiguration, "min_quantity" | "max_quantity"> & {
@@ -157,6 +169,13 @@ function parseProductConfig(rawConfig: unknown): ProductConfiguration {
         }));
     };
 
+    const parseStringArray = (value: unknown): string[] => {
+      if (!Array.isArray(value)) return [];
+      return value
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter((item) => item.length > 0);
+    };
+
     return {
       sizes: normalizeSizes(parsed.sizes as ProductConfigurationSize[] | undefined),
       materials: normalizeMaterials(parsed.materials as ProductConfigurationMaterial[] | undefined),
@@ -170,6 +189,21 @@ function parseProductConfig(rawConfig: unknown): ProductConfiguration {
         : [],
       min_quantity: parseNumber(parsed.min_quantity),
       max_quantity: parseNumber(parsed.max_quantity),
+      product_type:
+        typeof parsed === "object" && parsed && "product_type" in parsed && typeof parsed.product_type === "string"
+          ? parsed.product_type
+          : null,
+      possibilities: parseStringArray((parsed as RawProductConfig & { possibilities?: unknown }).possibilities),
+      stock:
+        typeof parsed === "object" && parsed && "stock" in parsed
+          ? parseNumber((parsed as { stock?: unknown }).stock)
+          : null,
+      base_colors: parseStringArray((parsed as RawProductConfig & { base_colors?: unknown }).base_colors),
+      serigraphy_colors: parseStringArray((parsed as RawProductConfig & { serigraphy_colors?: unknown }).serigraphy_colors),
+      unit_price:
+        typeof parsed === "object" && parsed && "unit_price" in parsed
+          ? parseNumber((parsed as { unit_price?: unknown }).unit_price)
+          : null,
     };
   } catch (error) {
     console.error("parseProductConfig", error);
@@ -242,12 +276,12 @@ export function summarizeProductStyle(style: ProductStyle): { badges: string[]; 
     badges.push(configuration.materials[0].label);
   }
 
-  if (configuration.colors.length > 0) {
-    badges.push(`${configuration.colors.length} colores`);
+  if (configuration.product_type) {
+    badges.push(configuration.product_type);
   }
 
-  if (configuration.productionSpeeds.length > 0) {
-    badges.push(configuration.productionSpeeds[0].label);
+  if (configuration.base_colors.length > 0) {
+    badges.push(`${configuration.base_colors.length} colores base`);
   }
 
   if (configuration.highlights.length > 0) {
@@ -261,12 +295,17 @@ export function summarizeProductStyle(style: ProductStyle): { badges: string[]; 
     if (configuration.max_quantity) {
       highlights.push(`Pedido máximo ${configuration.max_quantity} u.`);
     }
-    if (configuration.quantities.length > 0) {
-      const labels = configuration.quantities.map((quantity) => `${quantity.quantity} u.`);
-      highlights.push(`Presentaciones: ${labels.join(", ")}`);
+    if (configuration.possibilities.length > 0) {
+      highlights.push(`Variantes: ${configuration.possibilities.join(", ")}`);
+    }
+    if (configuration.stock !== null && configuration.stock !== undefined) {
+      highlights.push(`Stock: ${configuration.stock} u.`);
+    }
+    if (configuration.unit_price !== null && configuration.unit_price !== undefined) {
+      highlights.push(`Precio de referencia $${configuration.unit_price.toFixed(2)}`);
     }
     if (configuration.sizes.length > 1) {
-      highlights.push(`${configuration.sizes.length} medidas listas para usar.`);
+      highlights.push(`${configuration.sizes.length} medidas configuradas.`);
     }
   }
 


### PR DESCRIPTION
## Summary
- restructure the admin producto creation form to capture type, variantes, colores, stock, precios y permitir subir imágenes
- actualizar la acción de guardado y el esquema de contenido para almacenar la nueva ficha comercial y mostrarla en el listado de administración
- renovar la vista pública/privada del diseño para exhibir los detalles comerciales en lugar del editor interactivo

## Testing
- npm run lint *(fails: Next.js lint setup prompts for configuration in this environment)*
- npm run build *(fails: Next.js cannot download Google Fonts without external network access)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ba62290c8331a3e3d66bbb2f21ac